### PR TITLE
Remove Redundant Equipool Listing

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -42,13 +42,6 @@
     ]
   },
   {
-    "poolName": "Equipool",
-    "url": "https://equipool.1ds.us/getting_started",
-    "searchStrings": [
-      "equipool"
-    ]
-  },
-  {
     "poolName": "Equipool Europe",
     "url": "https://equipool.1ds.us/getting_started",
     "searchStrings": [


### PR DESCRIPTION
This listing inhibits the explorer from properly listing the NA and Euro stratums, listing blocks find by those as simply "Equipool". Removing this will allow the other two listings to match.